### PR TITLE
feature: initial Ubuntu support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,6 +32,10 @@ platforms:
       extra_vars:
         ansible_python_interpreter: '/usr/local/bin/python'
 
+  - name: ubuntu-18.04-amd64
+    driver:
+      box: trombik/ansible-ubuntu-18.04-amd64
+
 suites:
   - name: default
     provisioner:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,6 @@ script:
   #
   - "if [ ! -f .private_repo ]; then ansible-playbook tests/travisci/tests.yml -i tests/travisci/inventory --syntax-check; fi"
 
-  # use recent ruby, instead of default ruby 1.9
-  - rvm install 2.5.1
-  - rvm use 2.5.1
-
   # download the QA scripts
   - git clone https://github.com/trombik/qansible.git
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,9 +2,10 @@
 buildbot_worker_user: "{{ __buildbot_worker_user }}"
 buildbot_worker_group: "{{ __buildbot_worker_group }}"
 buildbot_worker_package: "{{ __buildbot_worker_package }}"
+buildbot_worker_extra_packages: []
 buildbot_worker_service: "{{ __buildbot_worker_service }}"
 buildbot_worker_root_dir: "{{ __buildbot_worker_root_dir }}"
-buildbot_worker_conf_dir: "{{ buildbot_worker_root_dir }}"
+buildbot_worker_conf_dir: "{{ __buildbot_worker_conf_dir }}"
 buildbot_worker_conf_file: "{{ buildbot_worker_conf_dir }}/buildbot.tac"
 buildbot_worker_config: ""
 buildbot_worker_flags: ""

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 galaxy_info:
+  role_name: buildbot_worker
   author: Tomoyuki Sakurai
   description: Configure buildbot worker
   company: N/A

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -1,0 +1,16 @@
+---
+- name: Install buildbot_worker
+  apt:
+    name: "{{ buildbot_worker_package }}"
+    state: present
+
+- name: Create /etc/default/buildbot-worker
+  template:
+    src: Debian.default.j2
+    dest: /etc/default/buildbot-worker
+  when: 1 == 0
+
+- name: Enable buildbot_worker_service
+  service:
+    name: "{{ buildbot_worker_service }}"
+    enabled: yes

--- a/tasks/install-FreeBSD.yml
+++ b/tasks/install-FreeBSD.yml
@@ -5,7 +5,13 @@
     name: "{{ buildbot_worker_package }}"
     state: present
 
+- name: Install buildbot_worker_extra_packages
+  pkgng:
+    name: "{{ buildbot_worker_extra_packages }}"
+    state: present
+
 - name: Create buildbot_worker_group
+  # XXX the port does not crate user
   group:
     name: "{{ buildbot_worker_group }}"
 

--- a/templates/Debian.default.j2
+++ b/templates/Debian.default.j2
@@ -1,0 +1,2 @@
+# Managed by ansible
+{{ buildbot_worker_flags }}

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -3,6 +3,16 @@
   roles:
     - ansible-role-buildbot_worker
   vars:
+    buildbot_worker_flags_freebsd: ""
+    buildbot_worker_flags_ubuntu: |
+      WORKER_ENABLED[1]=1                    # 1-enabled, 0-disabled
+      WORKER_NAME[1]="default"               # short name printed on start/stop
+      WORKER_USER[1]="buildbot"              # user to run worker as
+      WORKER_BASEDIR[1]="{{ buildbot_worker_conf_dir }}"  # basedir to worker (absolute path)
+      WORKER_OPTIONS[1]=""                   # buildbot options
+      WORKER_PREFIXCMD[1]=""                 # prefix command, i.e. nice, linux32, dchroot
+
+    buildbot_worker_flags: "{% if ansible_os_family == 'FreeBSD' %}{{ buildbot_worker_flags_freebsd }}{% elif ansible_os_family == 'Debian' %}{{ buildbot_worker_flags_ubuntu }}{% endif %}"
     buildbot_worker_config: |
       import os
       from buildbot_worker.bot import Worker

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -4,14 +4,20 @@ require "serverspec"
 package = case os[:family]
           when "freebsd"
             "devel/py-buildbot-worker"
+          when "ubuntu"
+            "python3-buildbot-worker"
           end
 service = case os[:family]
           when "freebsd"
             "buildbot-worker"
+          when "ubuntu"
+            "buildbot-worker@default"
           end
 config_dir = case os[:family]
              when "freebsd"
                "/usr/local/etc/buildbot_worker"
+             when "ubuntu"
+               "/var/lib/buildbot/workers/default"
              end
 config  = "#{config_dir}/buildbot.tac"
 user    = "buildbot"
@@ -46,6 +52,14 @@ end
 case os[:family]
 when "freebsd"
   describe file("/etc/rc.conf.d/buildbot_worker") do
+    it { should be_file }
+    it { should be_grouped_into default_group }
+    it { should be_owned_by default_user }
+    it { should be_mode 644 }
+    its(:content) { should match Regexp.escape("Managed by ansible") }
+  end
+when "ubuntu"
+  describe file("/etc/default/buildbot-worker") do
     it { should be_file }
     it { should be_grouped_into default_group }
     it { should be_owned_by default_user }

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,8 @@
+---
+__buildbot_worker_user: buildbot
+__buildbot_worker_group: buildbot
+__buildbot_worker_service: buildbot-worker@default
+__buildbot_worker_package: python3-buildbot-worker
+__buildbot_worker_extra_packages: []
+__buildbot_worker_root_dir: /var/lib/buildbot
+__buildbot_worker_conf_dir: "{{ __buildbot_worker_root_dir }}/workers/default"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -3,5 +3,6 @@ __buildbot_worker_user: buildbot
 __buildbot_worker_group: buildbot
 __buildbot_worker_service: buildbot-worker
 __buildbot_worker_package: devel/py-buildbot-worker
+__buildbot_worker_extra_packages: []
 __buildbot_worker_root_dir: /usr/local/etc/buildbot_worker
 __buildbot_worker_conf_dir: "{{ __buildbot_worker_root_dir }}"


### PR DESCRIPTION
however, the package is too old and the daemon of that version does not
exit until it successfully connects to a master. as a result, ansible
play fails with timeout.

support buildbot_worker_extra_packages